### PR TITLE
Hadoop.java doesn't close httpClient.

### DIFF
--- a/gateway-shell/src/main/java/org/apache/hadoop/gateway/shell/Hadoop.java
+++ b/gateway-shell/src/main/java/org/apache/hadoop/gateway/shell/Hadoop.java
@@ -134,11 +134,19 @@ public class Hadoop {
 
   public void shutdown() throws InterruptedException {
     executor.shutdownNow();
+    closeClient();
   }
 
   public boolean shutdown( long timeout, TimeUnit unit ) throws InterruptedException {
     executor.shutdown();
+    closeClient();
     return executor.awaitTermination( timeout, unit );
+  }
+  
+  private void closeClient(){
+    if(client!=null){
+      client.close();
+    }
   }
 
 }


### PR DESCRIPTION
There are too much permanent CLOSE_WAIT sockest, because hadoop.java shutdowns without closing HttpClient.
